### PR TITLE
test: fix spurious test failures

### DIFF
--- a/test/smart_shunt_task_test.rb
+++ b/test/smart_shunt_task_test.rb
@@ -33,7 +33,8 @@ describe OroGen.power_whisperpower.SmartShuntTask do
             )
         end.to { have_one_new_sample task.full_status_port }
 
-        assert_equal now.tv_sec, status.time.tv_sec
+        assert now < status.time
+        assert status.time < Time.now
     end
 
     it "outputs nothing on partial updates" do
@@ -95,7 +96,8 @@ describe OroGen.power_whisperpower.SmartShuntTask do
             )
         end.to { have_one_new_sample task.battery_status_port }
 
-        assert_equal now.tv_sec, status.time.tv_sec
+        assert now < status.time
+        assert status.time < Time.now
         assert_equal 283.15, status.temperature.kelvin
         assert_in_delta 0.45, status.charge
     end
@@ -111,7 +113,8 @@ describe OroGen.power_whisperpower.SmartShuntTask do
             )
         end.to { have_one_new_sample task.battery_dc_output_status_port }
 
-        assert_equal now.tv_sec, status.time.tv_sec
+        assert now < status.time
+        assert status.time < Time.now
         assert_in_delta 0.258, status.voltage
         assert_in_delta 77.2, status.current
     end


### PR DESCRIPTION
The tests were assuming that the time of a status is the time of
the first or last received CAN message.

This is not the case, and to be honest it's not clear whether
such a scheme would really be "better"
- this data would be used for slow monitoring, not high-frequency
  realtime processing
- some updates are aggregates of multiple messages, that can arrive
  with significant time differences

Just update the test to make sure the time is set to something
meaningful instead