### PR TITLE
invert the shunt-reported current

### DIFF
--- a/tasks/SmartShuntTask.cpp
+++ b/tasks/SmartShuntTask.cpp
@@ -39,7 +39,7 @@ static BatteryStatus toBatteryStatus(SmartShuntStatus const& status) {
     ret.temperature = status.temperature_bts;
     ret.charge = status.battery_charge;
     ret.voltage = status.battery_voltage;
-    ret.current = status.shunt_current;
+    ret.current = -status.shunt_current;
     return ret;
 }
 void SmartShuntTask::updateHook()

--- a/test/smart_shunt_task_test.rb
+++ b/test/smart_shunt_task_test.rb
@@ -101,7 +101,7 @@ describe OroGen.power_whisperpower.SmartShuntTask do
         assert now <= status.time
         assert status.time <= Time.now
         assert_in_delta 0.258, status.voltage
-        assert_in_delta 77.2, status.current
+        assert_in_delta -77.2, status.current
         assert_equal 283.15, status.temperature.kelvin
         assert_in_delta 0.45, status.charge
         assert_in_delta 22, status.max_current


### PR DESCRIPTION
It turned out that on Tupan the shunt was mounted backwards.
WhisperPower reports positive currents when charging and negative
when discharging (we implemented this driver thinking the reverse)

Since the battery status is a subtype of DCSourceStatus, invert
this when copying into our data structure (which expects positive
for source, negative for sink)