### PR TITLE
fix: The DCPowerCube component goes into exception if no data is received for a configurable time

### DIFF
--- a/power_whisperpower.orogen
+++ b/power_whisperpower.orogen
@@ -24,6 +24,7 @@ task_context "DCPowerCubeTask" do
     needs_configuration
 
     property "device_id", "/int", 1
+    property "io_read_timeout", "/base/Time"
 
     # CAN messages coming from the device
     input_port("can_in", "/canbus/Message")
@@ -47,7 +48,9 @@ task_context "DCPowerCubeTask" do
     # Output of the DC Cube itself
     output_port "dc_output_status", "/power_base/DCSourceStatus"
 
-    port_driven
+    exception_states :IO_TIMEOUT
+
+    port_driven timeout: 0.1
 end
 
 # Driver component for the PMG Genverter

--- a/tasks/DCPowerCubeTask.cpp
+++ b/tasks/DCPowerCubeTask.cpp
@@ -9,6 +9,7 @@ DCPowerCubeTask::DCPowerCubeTask(std::string const& name)
     : DCPowerCubeTaskBase(name)
     , m_driver(1)
 {
+    _io_read_timeout.set(base::Time::fromSeconds(2));
 }
 
 DCPowerCubeTask::~DCPowerCubeTask()

--- a/tasks/DCPowerCubeTask.cpp
+++ b/tasks/DCPowerCubeTask.cpp
@@ -22,6 +22,7 @@ bool DCPowerCubeTask::configureHook()
     }
 
     m_driver = DCPowerCube(_device_id.get());
+    m_io_read_timeout = _io_read_timeout.get();
     return true;
 }
 bool DCPowerCubeTask::startHook()
@@ -30,6 +31,7 @@ bool DCPowerCubeTask::startHook()
         return false;
     }
     m_driver.resetFullUpdate();
+    m_deadline = base::Time::now() + m_io_read_timeout;
     return true;
 }
 
@@ -80,13 +82,14 @@ void DCPowerCubeTask::updateHook()
     DCPowerCubeTaskBase::updateHook();
 
     canbus::Message can_in;
+
     while (_can_in.read(can_in, false) == RTT::NewData) {
+        m_deadline = base::Time::now() + m_io_read_timeout;
         m_driver.process(can_in);
 
         if (!m_driver.hasFullUpdate()) {
             continue;
         }
-
         auto status = m_driver.getStatus();
         _full_status.write(status);
         m_driver.resetFullUpdate();
@@ -94,6 +97,10 @@ void DCPowerCubeTask::updateHook()
         _ac_generator_status.write(toACGeneratorStatus(status));
         _ac_grid_status.write(toACGridStatus(status));
         _dc_output_status.write(toDCSourceStatus(status));
+    }
+    if (base::Time::now() > m_deadline)
+    {
+        return exception(IO_TIMEOUT);
     }
 }
 void DCPowerCubeTask::errorHook()

--- a/tasks/DCPowerCubeTask.hpp
+++ b/tasks/DCPowerCubeTask.hpp
@@ -20,6 +20,8 @@ namespace power_whisperpower {
 
     protected:
         DCPowerCube m_driver;
+        base::Time m_io_read_timeout;
+        base::Time m_deadline;
 
     public:
         /** TaskContext constructor for DCPowerCubeTask


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
[sc-73213]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
